### PR TITLE
Photo delegates #url and #thumb to image (#1)

### DIFF
--- a/lib/simplest_photo/model/photo.rb
+++ b/lib/simplest_photo/model/photo.rb
@@ -17,6 +17,8 @@ module SimplestPhoto
                              if: :image_changed?
 
           scope :by_name, -> { order(name: :asc) }
+
+          delegate :url, :thumb, to: :image
         end
       end
 


### PR DESCRIPTION
This way, we can just say `@user.avatar.url` instead of `@user.avatar.image.url`.
