### PR TITLE
Accept Additional Validation Options

### DIFF
--- a/lib/simplest_photo/has_photo.rb
+++ b/lib/simplest_photo/has_photo.rb
@@ -1,7 +1,7 @@
 module SimplestPhoto
   module HasPhoto
 
-    def has_photo(name, options = {})
+    def has_photo(name, required: false, on: nil)
       has_one :"#{name}_attachment",
               -> { where(attachable_name: name) },
               as:         :attachable,
@@ -12,8 +12,8 @@ module SimplestPhoto
               through: "#{name}_attachment",
               source:  :photo
 
-      if options.delete(:required)
-        validates name, options.merge(presence: true)
+      if required
+        validates name, presence: true, on: on
       end
 
       foreign_key = "#{name}_id"

--- a/lib/simplest_photo/has_photo.rb
+++ b/lib/simplest_photo/has_photo.rb
@@ -1,7 +1,7 @@
 module SimplestPhoto
   module HasPhoto
 
-    def has_photo(name, required: false)
+    def has_photo(name, options = {})
       has_one :"#{name}_attachment",
               -> { where(attachable_name: name) },
               as:         :attachable,
@@ -12,8 +12,8 @@ module SimplestPhoto
               through: "#{name}_attachment",
               source:  :photo
 
-      if required
-        validates name, presence: true
+      if options.delete(:required)
+        validates name, options.merge(presence: true)
       end
 
       foreign_key = "#{name}_id"


### PR DESCRIPTION
The goal of this PR is to allow users to pass through additional validation options aside from `required: true`.  I ran into a case where I need to seed records that are not user-creatable, but users should be able to update with photos and other things that are required on update.

Basically, I'd like us to be able to do the following:

```
has_photo :hero_image, required: true, on: :update
```
