### PR TITLE
Prevent multiple copies of the same crop

### DIFF
--- a/lib/generators/templates/migrations/create_photo_croppings.rb
+++ b/lib/generators/templates/migrations/create_photo_croppings.rb
@@ -7,7 +7,7 @@ class CreatePhotoCroppings < ActiveRecord::Migration
 
       t.timestamps null: false
 
-      t.index :signature
+      t.index :signature, unique: true
     end
 
     add_foreign_key :photo_croppings, :photos, on_delete: :cascade

--- a/lib/simplest_photo/model/photo_cropping.rb
+++ b/lib/simplest_photo/model/photo_cropping.rb
@@ -8,6 +8,8 @@ module SimplestPhoto
 
           before_destroy :delete_file
 
+          validates :signature, uniqueness: true
+
 
           private
 

--- a/lib/simplest_photo/url_helper.rb
+++ b/lib/simplest_photo/url_helper.rb
@@ -20,10 +20,16 @@ module SimplestPhoto
       end
 
       config.before_serve do |job, env|
-        photo = Photo.with_image_uid!(job.uid)
-        uid   = job.store
+        existing = PhotoCropping.find_by(signature: job.signature)
 
-        PhotoCropping.create!(photo: photo, uid: uid, signature: job.signature)
+        if existing
+          throw :halt, [301, { 'Location' => job.app.remote_url_for(existing.uid) }, [""]]
+        else
+          photo = Photo.with_image_uid!(job.uid)
+          uid   = job.store
+
+          PhotoCropping.create!(photo: photo, uid: uid, signature: job.signature)
+        end
       end
     end
 


### PR DESCRIPTION
We were seeing an issue on SavingPlaces.org where we were getting a lot of requests for the same /media URL, which was generating the same cropping over and over again (and uploading the same image to S3 1500+ times).

This update takes advantage of the functionality described [here](http://markevans.github.io/dragonfly/configuration/) and checks for an existing cropping and, if it finds one, throws `halt` with a rack redirect response ([relevant DF code](https://github.com/markevans/dragonfly/blob/241a4ed802f3b612e5a00f18a50605321c9f7323/lib/dragonfly/server.rb#L59-L64)). It also enforces cropping signature uniqueness at the DB + model levels.
