### PR TITLE
Generalize Attachment Functionality to Improve Extensibility

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -87,3 +87,13 @@ Standard stuff. It also defines `#headshot_id` and `#headshot_id=` accessors, wh
 
     f.input :headshot_id, collection: Photo.all
 
+### Customizations
+
+To customize the valid image file extensions (which defaults to allowing `.jpg`, `.jpeg`, or `.png` extensions), override the `valid_image_extensions` method in the generated `Photo` model:
+```ruby
+class Photo < ActiveRecord::Base
+  def valid_image_extensions
+    %w(jpg jpeg png gif)
+  end
+end
+```

--- a/lib/simplest_photo.rb
+++ b/lib/simplest_photo.rb
@@ -1,5 +1,6 @@
 require 'simplest_photo/model/has_attachment'
 require 'simplest_photo/model/attachment'
+require 'simplest_photo/model/validations'
 require 'simplest_photo/model/photo'
 require 'simplest_photo/model/photo_attachment'
 require 'simplest_photo/model/photo_cropping'

--- a/lib/simplest_photo.rb
+++ b/lib/simplest_photo.rb
@@ -1,3 +1,5 @@
+require 'simplest_photo/model/has_attachment'
+require 'simplest_photo/model/attachment'
 require 'simplest_photo/model/photo'
 require 'simplest_photo/model/photo_attachment'
 require 'simplest_photo/model/photo_cropping'

--- a/lib/simplest_photo/has_photo.rb
+++ b/lib/simplest_photo/has_photo.rb
@@ -1,58 +1,11 @@
 module SimplestPhoto
   module HasPhoto
-
-    def has_photo(name, required: false, on: %i(create update))
-      has_one :"#{name}_attachment",
-              -> { where(attachable_name: name) },
-              as:         :attachable,
-              class_name: 'PhotoAttachment',
-              dependent:  :destroy
-
-      has_one name.to_sym,
-              through: "#{name}_attachment",
-              source:  :photo
-
-      if required
-        validates name, presence: true, on: on
-      end
-
-      foreign_key = "#{name}_id"
-
-      # Save the associated target that was set in the [attr]_id= method
-      # definition.
-      after_save do
-        if attribute_changed?(foreign_key)
-          association(name).replace(association(name).target)
-        end
-      end
-
-
-      define_method foreign_key do
-        ivar = "@#{foreign_key}"
-
-        return instance_variable_get(ivar) if instance_variable_defined?(ivar)
-
-        instance_variable_set(ivar, self.send(name).try(:id))
-      end
-
-      define_method "#{foreign_key}=" do |new_id|
-        ivar = "@#{foreign_key}"
-
-        unless new_id.to_i == instance_variable_get(ivar)
-          # For ActiveModel::Dirty
-          attribute_will_change!(foreign_key)
-
-          # Set the target of this association without saving to the database
-          association(name).target = Photo.where(id: new_id).first
-
-          instance_variable_set(ivar, new_id)
-        end
-      end
-
-      define_method "#{name}?" do
-        send(name).present?
-      end
+    def self.extended(base)
+      base.extend Model::HasAttachment
     end
 
+    def has_photo(name, options = {})
+      has_attachment name, options.merge(class_name: 'Photo')
+    end
   end
 end

--- a/lib/simplest_photo/model/attachment.rb
+++ b/lib/simplest_photo/model/attachment.rb
@@ -1,0 +1,26 @@
+module SimplestPhoto
+  module Model
+    module Attachment
+      def attached_to(resource)
+        belongs_to resource.to_sym
+
+        belongs_to :attachable,
+                   polymorphic: true,
+                   touch:       true
+
+        validates resource.to_sym, :attachable, presence: true
+
+        validates :"#{resource}_id",
+                  uniqueness: { scope: [:attachable_id, :attachable_type, :attachable_name] }
+
+        class_eval do
+          scope :by_attachable, -> {
+            order(attachable_type: :asc,
+                  attachable_id:   :asc,
+                  attachable_name: :asc)
+          }
+        end
+      end
+    end
+  end
+end

--- a/lib/simplest_photo/model/has_attachment.rb
+++ b/lib/simplest_photo/model/has_attachment.rb
@@ -1,0 +1,60 @@
+module SimplestPhoto
+  module Model
+    module HasAttachment
+      def has_attachment(name, class_name:, required: false, on: %i(create update), includes: nil)
+        klass = class_name.to_s.constantize
+
+        has_one :"#{name}_attachment",
+          -> { where attachable_name: name },
+          as:         :attachable,
+          class_name: "#{class_name}Attachment",
+          dependent:  :destroy
+
+        has_one name.to_sym,
+          -> { includes(includes) },
+          through: "#{name}_attachment",
+          source:  klass.model_name.singular.to_sym
+
+        if required
+          validates name, presence: true, on: on
+        end
+
+        foreign_key = "#{name}_id"
+
+        # Save the associated target that was set in the [attr]_id= method
+        # definition.
+        after_save do
+          if attribute_changed?(foreign_key)
+            association(name).replace(association(name).target)
+          end
+        end
+
+        define_method foreign_key do
+          ivar = "@#{foreign_key}"
+
+          return instance_variable_get(ivar) if instance_variable_defined?(ivar)
+
+          instance_variable_set(ivar, self.send(name).try(:id))
+        end
+
+        define_method "#{foreign_key}=" do |new_id|
+          ivar = "@#{foreign_key}"
+
+          unless new_id.to_i == instance_variable_get(ivar)
+            # For ActiveModel::Dirty
+            attribute_will_change!(foreign_key)
+
+            # Set the target of this association without saving to the database
+            association(name).target = klass.where(id: new_id).first
+
+            instance_variable_set(ivar, new_id)
+          end
+        end
+
+        define_method "#{name}?" do
+          send(name).present?
+        end
+      end
+    end
+  end
+end

--- a/lib/simplest_photo/model/photo.rb
+++ b/lib/simplest_photo/model/photo.rb
@@ -1,9 +1,10 @@
 module SimplestPhoto
   module Model
     module Photo
-
       def self.extended(base)
         base.class_eval do
+          extend SimplestPhoto::Model::Validations
+
           dragonfly_accessor :image
 
           has_many :photo_attachments, dependent: :destroy
@@ -11,21 +12,24 @@ module SimplestPhoto
 
           validates :name, :image, presence: true
 
-          validates_property :format,
-                             of: :image,
-                             in: %w(jpeg jpg png),
-                             if: :image_changed?
+          validates_attachment_property :format,
+            of: :image,
+            in: :valid_image_extensions,
+            if: :image_changed?
 
           scope :by_name, -> { order(name: :asc) }
 
           delegate :url, :thumb, to: :image
+
+          def valid_image_extensions
+            %w(jpeg jpg png)
+          end
         end
       end
 
       def with_image_uid!(uid)
         find_by!(image_uid: uid)
       end
-
     end
   end
 end

--- a/lib/simplest_photo/model/photo_attachment.rb
+++ b/lib/simplest_photo/model/photo_attachment.rb
@@ -1,28 +1,11 @@
 module SimplestPhoto
   module Model
     module PhotoAttachment
-
       def self.extended(base)
-        base.class_eval do
-          belongs_to :photo
+        base.extend Attachment
 
-          belongs_to :attachable,
-                     polymorphic: true,
-                     touch:       true
-
-          validates :photo, :attachable, presence: true
-
-          validates :photo_id,
-                    uniqueness: { scope: [:attachable_id, :attachable_type, :attachable_name] }
-
-          scope :by_attachable, -> do
-            order(attachable_type: :asc,
-                  attachable_id:   :asc,
-                  attachable_name: :asc)
-          end
-        end
+        base.attached_to :photo
       end
-
     end
   end
 end

--- a/lib/simplest_photo/model/validations.rb
+++ b/lib/simplest_photo/model/validations.rb
@@ -3,7 +3,7 @@ require 'active_model/validator'
 module SimplestPhoto
   module Model
     module Validations
-      class AttachmentPropertyValidator < Dragonfly::Model::Validations::PropertyValidator
+      class AttachmentPropertyValidator < ::Dragonfly::Model::Validations::PropertyValidator
         include ActiveModel::Validations::Clusivity
 
         def validate_each(model, attribute, attachment)
@@ -13,7 +13,7 @@ module SimplestPhoto
             end
           end
         rescue RuntimeError => e
-          Dragonfly.warn("validation of property #{property_name} of #{attribute} failed with error #{e}")
+          ::Dragonfly.warn("validation of property #{property_name} of #{attribute} failed with error #{e}")
           model.errors.add(attribute, message(nil, model))
         end
 

--- a/lib/simplest_photo/model/validations.rb
+++ b/lib/simplest_photo/model/validations.rb
@@ -1,0 +1,43 @@
+require 'active_model/validator'
+
+module SimplestPhoto
+  module Model
+    module Validations
+      class AttachmentPropertyValidator < Dragonfly::Model::Validations::PropertyValidator
+        include ActiveModel::Validations::Clusivity
+
+        def validate_each(model, attribute, attachment)
+          if attachment
+            unless include?(model, attachment.send(property_name))
+              model.errors.add(attribute, message(property, model))
+            end
+          end
+        rescue RuntimeError => e
+          Dragonfly.warn("validation of property #{property_name} of #{attribute} failed with error #{e}")
+          model.errors.add(attribute, message(nil, model))
+        end
+
+        private
+
+        def delimiter
+          @delimiter ||= options[:in] || options[:within] || options[:as]
+        end
+      end
+
+      private
+
+      def validates_attachment_property(property_name, options)
+        raise ArgumentError, "you need to provide the attribute which has the property, using :of => <attribute_name>" unless options[:of]
+
+        validates_with(
+          SimplestPhoto::Model::Validations::AttachmentPropertyValidator,
+          options.merge(
+            attributes:    [*options[:of]],
+            property_name: property_name
+          )
+        )
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
The purpose of this pull request is to be able to support other models like a `FileUpload` in the same way that SimplestPhoto handles a `Photo`.  We used this branch on TNC and it worked out pretty well.
