### PR TITLE
Inherit from ActiveRecord::Migration::Current

### DIFF
--- a/lib/generators/templates/migrations/create_photo_attachments.rb
+++ b/lib/generators/templates/migrations/create_photo_attachments.rb
@@ -1,4 +1,4 @@
-class CreatePhotoAttachments < ActiveRecord::Migration
+class CreatePhotoAttachments < ActiveRecord::Migration::Current
   def change
     create_table :photo_attachments do |t|
       t.references :photo,           null: false

--- a/lib/generators/templates/migrations/create_photo_attachments.rb
+++ b/lib/generators/templates/migrations/create_photo_attachments.rb
@@ -1,11 +1,20 @@
-class CreatePhotoAttachments < ActiveRecord::Migration::Current
+<%
+  parent_class = ActiveRecord::Migration
+  parent_class = parent_class[parent_class.current_version] if Rails::VERSION::MAJOR >= 5
+-%>
+
+class CreatePhotoAttachments < <%= parent_class.to_s %>
   def change
     create_table :photo_attachments do |t|
       t.references :photo,           null: false
       t.references :attachable,      null: false, polymorphic: true
       t.string     :attachable_name, null: false
 
+      <%- if Rails::VERSION::MAJOR >= 5 -%>
+      t.timestamps
+      <%- else -%>
       t.timestamps null: false
+      <%- end -%>
 
       t.index [:photo_id, :attachable_id, :attachable_type, :attachable_name],
               name: 'index_photo_attachments_on_attachable_fields',

--- a/lib/generators/templates/migrations/create_photo_croppings.rb
+++ b/lib/generators/templates/migrations/create_photo_croppings.rb
@@ -1,11 +1,20 @@
-class CreatePhotoCroppings < ActiveRecord::Migration::Current
+<%
+  parent_class = ActiveRecord::Migration
+  parent_class = parent_class[parent_class.current_version] if Rails::VERSION::MAJOR >= 5
+-%>
+
+class CreatePhotoCroppings < <%= parent_class.to_s %>
   def change
     create_table :photo_croppings do |t|
       t.references :photo,     null: false
       t.string     :signature, null: false
       t.string     :uid,       null: false
 
+      <%- if Rails::VERSION::MAJOR >= 5 -%>
+      t.timestamps
+      <%- else -%>
       t.timestamps null: false
+      <%- end -%>
 
       t.index :signature, unique: true
     end

--- a/lib/generators/templates/migrations/create_photo_croppings.rb
+++ b/lib/generators/templates/migrations/create_photo_croppings.rb
@@ -1,4 +1,4 @@
-class CreatePhotoCroppings < ActiveRecord::Migration
+class CreatePhotoCroppings < ActiveRecord::Migration::Current
   def change
     create_table :photo_croppings do |t|
       t.references :photo,     null: false

--- a/lib/generators/templates/migrations/create_photos.rb
+++ b/lib/generators/templates/migrations/create_photos.rb
@@ -1,4 +1,4 @@
-class CreatePhotos < ActiveRecord::Migration
+class CreatePhotos < ActiveRecord::Migration::Current
   def change
     create_table :photos do |t|
       t.string :name,       null: false

--- a/lib/generators/templates/migrations/create_photos.rb
+++ b/lib/generators/templates/migrations/create_photos.rb
@@ -1,11 +1,20 @@
-class CreatePhotos < ActiveRecord::Migration::Current
+<%
+  parent_class = ActiveRecord::Migration
+  parent_class = parent_class[parent_class.current_version] if Rails::VERSION::MAJOR >= 5
+-%>
+
+class CreatePhotos < <%= parent_class.to_s %>
   def change
     create_table :photos do |t|
       t.string :name,       null: false
       t.string :image_uid,  null: false
       t.string :image_name
 
+      <%- if Rails::VERSION::MAJOR >= 5 -%>
+      t.timestamps
+      <%- else -%>
       t.timestamps null: false
+      <%- end -%>
     end
   end
 end


### PR DESCRIPTION
I'm not 100% sure if this is the right approach.

This fixes the bug for Rails 5, but it may be better to specify the version? I borrowed the `::Current` syntax from an ActiveAdmin generator.